### PR TITLE
move generator bugfixes

### DIFF
--- a/src/move_generator/perft/CMakeLists.txt
+++ b/src/move_generator/perft/CMakeLists.txt
@@ -1,8 +1,4 @@
 add_library(perft perft.cpp)
 target_sources(perft PRIVATE FILE_SET CXX_MODULES FILES perft.cppm)
-target_link_libraries(
-  perft
-  PUBLIC core
-  PRIVATE move_generator
-)
+target_link_libraries(perft PUBLIC move_generator)
 add_subdirectory(tests)

--- a/src/move_generator/perft/perft.cpp
+++ b/src/move_generator/perft/perft.cpp
@@ -70,7 +70,7 @@ class Visitor : public move_generator::Visitor<Visitor<depth>> {
 };
 }  // namespace
 
-std::expected<std::uint64_t, std::string_view> run(const Position& position, const Ply depth) {
+std::expected<std::uint64_t, std::string_view> perft(const Position& position, const Ply depth) {
   switch (std::to_underlying(depth)) {
 #define _(DEPTH)                                                           \
   case DEPTH:                                                              \

--- a/src/move_generator/perft/perft.cppm
+++ b/src/move_generator/perft/perft.cppm
@@ -9,5 +9,5 @@ export module prodigy.move_generator.perft;
 import prodigy.core;
 
 export namespace prodigy::move_generator::perft {
-std::expected<std::uint64_t, std::string_view> run(const Position&, Ply);
+std::expected<std::uint64_t, std::string_view> perft(const Position&, Ply);
 }

--- a/src/move_generator/perft/tests/perft.cpp
+++ b/src/move_generator/perft/tests/perft.cpp
@@ -1,19 +1,38 @@
 #include <catch2/catch_test_macros.hpp>
 #include <catch2/generators/catch_generators.hpp>
+#include <cstdint>
 #include <string_view>
+#include <utility>
 
 import prodigy.core;
+import prodigy.move_generator;
 import prodigy.move_generator.perft;
 
 namespace prodigy::move_generator::perft {
 namespace {
+TEST_CASE("perft") {
+#ifdef NDEBUG
+  const auto [fen, depth, leaf_node_count] = GENERATE(table<std::string_view, Ply, std::uint64_t>({
+      {STARTING_FEN, Ply{7}, 3'195'901'860},
+  }));
+#else
+  const auto [fen, depth, leaf_node_count] = GENERATE(table<std::string_view, Ply, std::uint64_t>({
+      {STARTING_FEN, Ply{5}, 4'865'609},
+  }));
+#endif
+  static_cast<void>(init());
+  INFO(fen);
+  INFO("depth " << std::to_underlying(depth));
+  REQUIRE(perft(parse_fen(fen).value(), depth).value() == leaf_node_count);
+}
+
 TEST_CASE("invalid") {
   const auto [fen, depth, error] = GENERATE(table<std::string_view, Ply, std::string_view>({
       {STARTING_FEN, Ply{0}, "Invalid depth."},
       {STARTING_FEN, Ply{9}, "Invalid depth."},
   }));
   INFO(fen);
-  const auto result = run(parse_fen(fen).value(), depth);
+  const auto result = perft(parse_fen(fen).value(), depth);
   REQUIRE_FALSE(result.has_value());
   REQUIRE(result.error() == error);
 }

--- a/src/move_generator/walk.cppm
+++ b/src/move_generator/walk.cppm
@@ -63,7 +63,8 @@ template <Color side_to_move, CastlingRights castling_rights>
 void walk_king_moves(const Board& board, const Square king_origin, const auto& visit_move) {
   const auto king_danger_set = [&] {
     auto king_danger_set = pawn_left_attack_set(!side_to_move, board[!side_to_move, PieceType::PAWN]) |
-                           pawn_right_attack_set(!side_to_move, board[!side_to_move, PieceType::PAWN]);
+                           pawn_right_attack_set(!side_to_move, board[!side_to_move, PieceType::PAWN]) |
+                           king_attack_set(square_of(board[!side_to_move, PieceType::KING]));
     for_each_square(board[!side_to_move, PieceType::KNIGHT],
                     [&](const auto origin) { king_danger_set |= knight_attack_set(origin); });
     const auto kingless_occupancy = board.occupancy() ^ board[side_to_move, PieceType::KING];
@@ -90,7 +91,6 @@ Bitboard make_checkers(const Board& board, const Square king_origin) noexcept {
               (board[!side_to_move, PieceType::BISHOP] | board[!side_to_move, PieceType::QUEEN]);
   checkers |= rook_attack_set(king_origin, board.occupancy()) &
               (board[!side_to_move, PieceType::ROOK] | board[!side_to_move, PieceType::QUEEN]);
-  checkers |= king_attack_set(king_origin) & board[!side_to_move, PieceType::KING];
   return checkers;
 }
 


### PR DESCRIPTION
- scoped_move: fix dangling reference to en_passant_target and undo logic to ensure that only one en passant target is set.
- walk: include opponent king attack set in the king danger set.